### PR TITLE
It is very important to stop IRIS during the build 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,5 @@ COPY src/iris/ /data/src/
 COPY iris.script /tmp/
 
 RUN iris start IRIS \
-	&& iris session IRIS < /tmp/iris.script
+	&& iris session IRIS < /tmp/iris.script \
+    && iris stop IRIS quietly


### PR DESCRIPTION
In some cases, changes were done during docker build without the correct stop just disappear after build.